### PR TITLE
Corrected reference

### DIFF
--- a/pytherm.py
+++ b/pytherm.py
@@ -17,8 +17,9 @@ OHM_sensortypes = [
  'Voltage', 'Clock', 'Temperature', 'Load', 'Fan', 'Flow', 'Control', 'Level', 'Factor', 'Power', 'Data', 'SmallData'
 ]
 
+
 def init_OHM() :
- clr.AddReference(os.getcwd() + R'\OpenHardwareMonitorLib.dll')
+ clr.AddReference( os.path.abspath( os.path.dirname( __file__ ) ) + R'\OpenHardwareMonitorLib.dll' )
  from OpenHardwareMonitor import Hardware
  hw = Hardware.Computer()
  hw.MainboardEnabled, hw.CPUEnabled, hw.RAMEnabled, hw.GPUEnabled, hw.HDDEnabled = True, True, True, True, True


### PR DESCRIPTION
PyTherm can now be called from outside, not only its own directory.